### PR TITLE
Minor parameter wording fix

### DIFF
--- a/src/pyquake3d/config.py
+++ b/src/pyquake3d/config.py
@@ -66,7 +66,7 @@ def readPara(data_dir):
     Para['Rock density']=float(Para0['Rock density'])
     Para['InputHetoparamter']=Para0['InputHetoparamter']=='True'
     Para['Inputparamter file']=Para0['Inputparamter file']
-    Para['Shearing zone width']=float(Para0['Shearing zone width'])
+    Para['Shear zone width']=float(Para0['Shear zone width'])
 
     try:
         Para['If Coupledthermal']=Para0['If Coupledthermal']=='True'


### PR DESCRIPTION
The terms in parameter.py for examples uses "Shear zone width" instead of "Shearing zone width"